### PR TITLE
Use jessie-backports which allows apt-get install of letsencrypt.  Ge…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
-FROM debian:jessie
+FROM debian:jessie-backports
+#Changed to the backports version so that I could install letsencrypt with the package manager
+#I was getting stuck on the python setup of "cryptography" like several others
 
-WORKDIR /
-ENV DEBIAN_FRONTEND=noninteractive
-ENV CERTBOT_VERSION=0.8.1
 RUN apt-get update \
-  && apt-get install -y unzip curl python-pip \
-  && pip install --upgrade pip \
-  && pip install virtualenv --upgrade \
-  && curl -Ls -o /certbot.zip https://github.com/certbot/certbot/archive/v${CERTBOT_VERSION}.zip \
-  && unzip certbot.zip \
-  && mv certbot-${CERTBOT_VERSION} certbot \
-  && cd certbot \
-  && ./certbot-auto --os-packages-only --noninteractive \
+  && apt-get install -y letsencrypt -t jessie-backports \
+  && apt-get install -y curl -t jessie-backports \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 EXPOSE 80
@@ -19,5 +12,8 @@ EXPOSE 80
 WORKDIR /certbot
 COPY run.sh /certbot/run.sh
 COPY post_cert.py /certbot/post_cert.py
+
+#I added this line because my docker containers seemed to be not getting my updates
+RUN sh -c 'touch /certbot/run.sh' && sh -c 'touch /certbot/post_cert.py'
 
 ENTRYPOINT ["/certbot/run.sh"]

--- a/letsencrypt-dcos.json
+++ b/letsencrypt-dcos.json
@@ -20,7 +20,7 @@
       }
     ],
     "docker": {
-      "image": "mesosphere/letsencrypt-dcos:v1.0.3",
+      "image": "dashaun/letsencrypt-dcos",
       "network": "BRIDGE",
       "portMappings": [
         {

--- a/run.sh
+++ b/run.sh
@@ -22,8 +22,8 @@ done
 echo "DOMAIN_ARGS: ${DOMAIN_ARGS}"
 echo "DOMAIN_FIRST: ${DOMAIN_FIRST}"
 
-echo "Running certbot-auto to generate initial signed cert"
-./certbot-auto --no-self-upgrade certonly --standalone \
+echo "Running certbot to generate initial signed cert instead of cerbot-auto with this updated Dockerfile (dashaun/letsencrypt-dcos)"
+certbot certonly --standalone \
   --standalone-supported-challenges http-01 $DOMAIN_ARGS \
   --email $LETSENCRYPT_EMAIL --agree-tos --noninteractive --no-redirect \
   --rsa-key-size 4096 --expand


### PR DESCRIPTION
…ts round the python environment setup issues (cryptography).

I ran into problems getting this to work directly from the blog post, another user shared the same issues here:

https://github.com/mesosphere/letsencrypt-dcos/issues/4